### PR TITLE
consistency: do not include www in github url

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -4,7 +4,7 @@
 # about: Generate multiple invite tokens
 # version: 0.2
 # author: Arpit Jalan
-# url: https://www.github.com/discourse/discourse-invite-tokens
+# url: https://github.com/discourse/discourse-invite-tokens
 
 enabled_site_setting :invite_tokens_enabled
 


### PR DESCRIPTION
Why did I notice? Pfaffmanager uses `/admin/plugins.json` to see what plugins are installed and uses that URL as part of a regex to remove the plugin from `app.yml`. It took me a while to figure out why it wouldn't delete this one! I might have tweaked my code, but this seems to be the only plugin that I've noticed this in. And github doesn't use www.