### PR TITLE
DEV: Update specs in preparation for core tweak

### DIFF
--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -14,7 +14,7 @@ describe Invite do
     let(:existing_user) { Fabricate(:user, email: invite.email) }
 
     it 'redeems the invite from token' do
-      Invite.redeem_from_token(invite.invite_key, 'user@example.com')
+      Invite.redeem_from_token(invite.invite_key, 'test@example.com')
       invite.reload
       expect(invite).to be_redeemed
     end

--- a/spec/requests/discourse_invite_tokens_controller_spec.rb
+++ b/spec/requests/discourse_invite_tokens_controller_spec.rb
@@ -9,7 +9,7 @@ describe DiscourseInviteTokens do
 
   describe 'redeem_invite_token' do
     let(:user) { Fabricate(:coding_horror) }
-    let(:invite) { Fabricate(:invite, invited_by: user, emailed_status: Invite.emailed_status_types[:not_required]) }
+    let(:invite) { Fabricate(:invite, invited_by: user, emailed_status: Invite.emailed_status_types[:not_required], email: nil) }
     context 'success' do
 
       before do
@@ -19,6 +19,7 @@ describe DiscourseInviteTokens do
       it 'logs in the user' do
         events = DiscourseEvent.track_events do
           put "/invite-token/redeem/#{invite.invite_key}?email=foo@bar.com"
+          expect(response.status).to eq(302)
         end
 
         expect(events.map { |event| event[:event_name] }).to include(


### PR DESCRIPTION
The user-facing behaviour here will be unchanged. It's just that the specs were relying on some incorrect quirks of core's implementation.

See https://github.com/discourse/discourse/pull/17173