### PR TITLE
DEV: Replace deprecated EmailValidator.email_regex

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -79,7 +79,7 @@ after_initialize do
       invite = Invite.find_by(invite_key: params[:token])
 
       if invite.present? && !invite.redeemed?
-        if (EmailValidator.email_regex =~ params[:email])
+        if (EmailAddressValidator.email_regex =~ params[:email])
           @email = params[:email]
           @username = params[:username]
           @name = params[:name]


### PR DESCRIPTION
### What is this change?

The `EmailValidator.email_regex` was moved to `EmailAddressValidator.email_regex` [here](https://github.com/discourse/discourse/commit/3bf3b9a4a5e066598482bc7add7a44dcb334178c) and marked for removal in 2.9.0. This PR replaces the usage in this plugin so we can remove it in core.